### PR TITLE
Add ability to set filename for licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added ability to set filename for licenses.
+
 ## [0.6.2] - 2022-04-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ _Theme: [GitHub Dark Default](https://marketplace.visualstudio.com/items?itemNam
 | Set author          | Set author for licenses.              |
 | Set year            | Set year for licenses.                |
 | Set extension       | Set extension for license files.      |
+| Set filename        | Set filename for license files.       |
 | Set token           | Set token for GitHub REST API access. |
 
 ## About access token

--- a/package.json
+++ b/package.json
@@ -80,6 +80,12 @@
       },
       {
         "category": "License",
+        "command": "license.setFilename",
+        "title": "Set filename",
+        "description": "Set filename for license files."
+      },
+      {
+        "category": "License",
         "command": "license.setToken",
         "title": "Set token",
         "description": "Set token for GitHub REST API access."
@@ -117,6 +123,11 @@
             "Create licenses with .md extension",
             "Create licenses with .txt extension"
           ]
+        },
+        "license.filename": {
+          "type": "string",
+          "default": "LICENSE",
+          "description": "License filename."
         },
         "license.token": {
           "type": "string",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -9,6 +9,7 @@ import {
   setAuthorProperty,
   setYearProperty,
   setExtensionProperty,
+  setFilenameProperty,
   setTokenProperty,
 } from "../config";
 import { getLicenses, getLicense } from "../api";
@@ -127,6 +128,13 @@ export const setExtension = vscode.commands.registerCommand(
   }
 );
 
+export const setFilename = vscode.commands.registerCommand(
+  "license.setFilename",
+  async () => {
+    await setFilenameProperty();
+  }
+);
+
 export const setToken = vscode.commands.registerCommand(
   "license.setToken",
   async () => {
@@ -161,8 +169,14 @@ const addLicense = async (license: License) => {
       .getConfiguration("license")
       .get("extension");
 
+    const filename: string =
+      vscode.workspace.getConfiguration("license").get("filename") ?? "LICENSE";
+
     if (extension !== undefined) {
-      const licensePath = path.join(folder.uri.fsPath, `LICENSE${extension}`);
+      const licensePath = path.join(
+        folder.uri.fsPath,
+        `${filename}${extension}`
+      );
 
       if (fs.existsSync(licensePath)) {
         const answer = await vscode.window.showInformationMessage(

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -168,11 +168,7 @@ const addLicense = async (license: License) => {
     const filename: string =
       vscode.workspace.getConfiguration("license").get("filename") ?? "LICENSE";
 
-    if (extension !== undefined) {
-      const licensePath = path.join(
-        folder.uri.fsPath,
-        `${filename}${extension}`
-      );
+    const licensePath = path.join(folder.uri.fsPath, `${filename}${extension}`);
 
     if (fs.existsSync(licensePath)) {
       const answer = await vscode.window.showInformationMessage(

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -90,6 +90,16 @@ export const setExtensionProperty = async () => {
   }
 };
 
+export const setFilenameProperty = async () => {
+  const value = await vscode.window.showInputBox({
+    prompt: "Set license filename.",
+  });
+
+  if (value) {
+    await setProp("filename", value);
+  }
+};
+
 export const setTokenProperty = async () => {
   const value = await vscode.window.showInputBox({
     prompt: "Set token for GitHub API access",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import {
   setAuthor,
   setYear,
   setExtension,
+  setFilename,
   setToken,
 } from "./commands";
 
@@ -19,5 +20,6 @@ export async function activate({
   subscriptions.push(setAuthor);
   subscriptions.push(setYear);
   subscriptions.push(setExtension);
+  subscriptions.push(setFilename);
   subscriptions.push(setToken);
 }


### PR DESCRIPTION
New command: `license.setFilename`.
New config parameter: `license.filename`.

Closes #508.