### PR TITLE
Use new coactions/setup-xvfb

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -45,7 +45,7 @@ jobs:
         run: yarn install
 
       - name: Run tests and make coverage
-        uses: GabrielBB/xvfb-action@v1.6
+        uses: coactions/setup-xvfb@v1
         with:
           run: yarn coverage
 


### PR DESCRIPTION
[GabrielBB/xvfb-action](https://github.com/GabrielBB/xvfb-action) is deprecated and recommends to use [coactions/setup-xvfb](https://github.com/coactions/setup-xvfb).