### PR TITLE
Add a mapping for non-standard license filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,12 @@
         "license.filename": {
           "type": "string",
           "default": "LICENSE",
-          "description": "License filename used unless one is defined by its usage conventions."
+          "description": "License filename used unless overridden by conventional name."
+        },
+        "license.useConventionalFilename": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to use license filenames defined by convention over the default."
         },
         "license.token": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
         "license.filename": {
           "type": "string",
           "default": "LICENSE",
-          "description": "License filename."
+          "description": "License filename used unless one is defined by its usage conventions."
         },
         "license.token": {
           "type": "string",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,7 +11,7 @@ import {
   setTokenProperty,
 } from "../config";
 import { getLicenses, getLicense } from "../api";
-import { replaceAuthor, replaceYear } from "../utils";
+import { replaceAuthor, replaceYear, getConventionalFilename } from "../utils";
 import { LicenseItem, License } from "../types";
 
 /**
@@ -76,17 +76,17 @@ const licenseToQuickPickItem = (
 ): QuickPickLicenseItem => {
   return l.key === defaultKey
     ? {
-        label: l.spdx_id ? l.spdx_id : l.key,
-        detail: l.name,
-        description: "Default",
-        key: l.key,
-        alwaysShow: true,
-      }
+      label: l.spdx_id ? l.spdx_id : l.key,
+      detail: l.name,
+      description: "Default",
+      key: l.key,
+      alwaysShow: true,
+    }
     : {
-        label: l.spdx_id ? l.spdx_id : l.key,
-        detail: l.name,
-        key: l.key,
-      };
+      label: l.spdx_id ? l.spdx_id : l.key,
+      detail: l.name,
+      key: l.key,
+    };
 };
 
 const showLicenses = async (
@@ -254,13 +254,12 @@ const addLicense = async (license: License, multiple: boolean) => {
       vscode.workspace.getConfiguration("license").get("extension") ?? "";
 
     const filename: string =
-      vscode.workspace.getConfiguration("license").get("filename") ?? "LICENSE";
+      getConventionalFilename(license.key) ?? vscode.workspace.getConfiguration("license").get("filename") ?? "LICENSE";
 
     const content = new TextEncoder().encode(text);
 
     const licensePath = vscode.Uri.file(
-      `${folder.uri.fsPath}/${filename}${
-        multiple ? `-${license.spdx_id?.toUpperCase()}` : ""
+      `${folder.uri.fsPath}/${filename}${multiple ? `-${license.spdx_id?.toUpperCase()}` : ""
       }${extension}`
     );
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,7 +11,7 @@ import {
   setTokenProperty,
 } from "../config";
 import { getLicenses, getLicense } from "../api";
-import { replaceAuthor, replaceYear, getConventionalFilename } from "../utils";
+import { replaceAuthor, replaceYear } from "../utils";
 import { LicenseItem, License } from "../types";
 
 /**
@@ -60,6 +60,10 @@ export const uncommonLicenses: LicenseItem[] = [
     html_url: "http://choosealicense.com/licenses/wtfpl/",
   },
 ];
+
+const conventionalFilenames = new Map<string, string>([
+  ["unlicense", "UNLICENSE"],
+]);
 
 interface QuickPickLicenseItem {
   label: string;
@@ -253,8 +257,13 @@ const addLicense = async (license: License, multiple: boolean) => {
     const extension: string =
       vscode.workspace.getConfiguration("license").get("extension") ?? "";
 
-    const filename: string =
-      getConventionalFilename(license.key) ?? vscode.workspace.getConfiguration("license").get("filename") ?? "LICENSE";
+    const filename: string = (function () {
+      let value: string | undefined = undefined;
+      if (Boolean(vscode.workspace.getConfiguration("license").get("useConventionalFilename")))
+        value ??= conventionalFilenames.get(license.key);
+      value ??= vscode.workspace.getConfiguration("license").get("filename");
+      return value ?? "LICENSE";
+    })();
 
     const content = new TextEncoder().encode(text);
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,11 +1,3 @@
-const filenameOverrides = new Map<string, string>([
-  ["unlicense", "UNLICENSE"],
-]);
-
-export function getConventionalFilename(licenseKey: string): string | undefined {
-  return filenameOverrides.get(licenseKey);
-};
-
 export const replaceAuthor = (author: string, key: string, text: string) => {
   switch (key) {
     case "agpl-3.0":

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,11 @@
+const filenameOverrides = new Map<string, string>([
+  ["unlicense", "UNLICENSE"],
+]);
+
+export function getConventionalFilename(licenseKey: string): string | undefined {
+  return filenameOverrides.get(licenseKey);
+};
+
 export const replaceAuthor = (author: string, key: string, text: string) => {
   switch (key) {
     case "agpl-3.0":


### PR DESCRIPTION
This should cover the case when the document endorsing a license suggests naming its file differently: GPL -> `COPYING`, Unlicense -> `UNLICENSE` (as opposed to `LICENSE`), and others I'm likely unaware of.

The list is incomplete and is currently hardcoded inside `utils.ts`.